### PR TITLE
Implement SyncState management API

### DIFF
--- a/app/dependencies/service.py
+++ b/app/dependencies/service.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.db import get_sqla_session
 from app.services.badge import BadgeService
 from app.services.feeder import FeederService
+from app.services.sync_state import SyncStateService
 
 
 def get_badge_service(session: AsyncSession = Depends(get_sqla_session)):
@@ -12,3 +13,7 @@ def get_badge_service(session: AsyncSession = Depends(get_sqla_session)):
 
 def get_feeder_service(session: AsyncSession = Depends(get_sqla_session)):
     return FeederService(session)
+
+
+def get_sync_state_service(session: AsyncSession = Depends(get_sqla_session)):
+    return SyncStateService(session)

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.routers.badges import router as router_badges
 from app.routers.feeder import router_feeder
 from app.routers.people import router as router_people
 from app.routers.places import router as router_directions
+from app.routers.sync_state import router as router_sync_state
 
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,7 @@ def get_app() -> FastAPI:
     app.include_router(router_people, tags=["people"])
     app.include_router(router_directions, tags=["directions"])
     app.include_router(router_badges, tags=["badges"])
+    app.include_router(router_sync_state, tags=["sync-state"])
 
     @app.exception_handler(RepresentativeError)
     def exception_handler(request, ex: RepresentativeError):  # noqa

--- a/app/routers/sync_state.py
+++ b/app/routers/sync_state.py
@@ -1,0 +1,60 @@
+import logging
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies.service import get_sync_state_service
+from app.services.sync_state import SyncStateService
+
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get(
+    "/sync-state",
+    summary="Получить SyncState для всех таблиц",
+)
+async def get_all(
+    service: SyncStateService = Depends(get_sync_state_service),
+):
+    return await service.get_all()
+
+
+@router.get(
+    "/sync-state/{table_name}",
+    summary="Получить SyncState для конкретной таблицы",
+)
+async def get_by_table(
+    table_name: str,
+    service: SyncStateService = Depends(get_sync_state_service),
+):
+    state = await service.get_by_table(table_name)
+    if not state:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return state
+
+
+@router.put(
+    "/sync-state/reset",
+    summary="Сбросить SyncState для всех таблиц",
+)
+async def reset_all(
+    service: SyncStateService = Depends(get_sync_state_service),
+):
+    return await service.reset_all()
+
+
+@router.put(
+    "/sync-state/{table_name}/reset",
+    summary="Сбросить SyncState для конкретной таблицы",
+)
+async def reset_table(
+    table_name: str,
+    service: SyncStateService = Depends(get_sync_state_service),
+):
+    state = await service.reset_table(table_name)
+    if not state:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return state

--- a/app/services/sync_state.py
+++ b/app/services/sync_state.py
@@ -1,0 +1,43 @@
+import logging
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.repo.sync_states import SyncStateRepo
+from database.orm.sync_state import SyncStateORM
+
+
+logger = logging.getLogger(__name__)
+
+SYNC_RESET_TIME = datetime(1970, 1, 1)
+
+
+class SyncStateService:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        self.repo = SyncStateRepo(session)
+
+    async def get_all(self) -> list[SyncStateORM]:
+        return await self.repo.get_all()
+
+    async def get_by_table(self, table_name: str) -> SyncStateORM | None:
+        return await self.repo.get_by_table_name(table_name)
+
+    async def reset_all(self) -> list[SyncStateORM]:
+        states = await self.repo.get_all()
+        for state in states:
+            state.last_sync = SYNC_RESET_TIME
+        await self.session.commit()
+        logger.info("SyncState reset for all tables")
+        return states
+
+    async def reset_table(self, table_name: str) -> SyncStateORM | None:
+        state = await self.repo.get_by_table_name(table_name)
+        if not state:
+            return None
+
+        state.last_sync = SYNC_RESET_TIME
+        await self.session.commit()
+
+        logger.info(f"SyncState reset for table {table_name}")
+        return state


### PR DESCRIPTION
Добавлены эндпоинты для управления состоянием синхронизации таблиц (SyncState): получение состояния для всех таблиц и конкретной таблицы по названию, а также сброс состояния для всех таблиц и конкретной таблицы по названию.

Реализован сервис SyncStateService и добавлена зависимость для его использования в роутерах.

Сброс устанавливает дату синхронизации на значение 1970-01-01.

Closes: #63 