### PR TITLE
fix: case-insensitive telegram search in /contacts/search

### DIFF
--- a/app/db/repos/person.py
+++ b/app/db/repos/person.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List
 from uuid import UUID
 
-from sqlalchemy import delete
+from sqlalchemy import delete, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.future import select
 
@@ -36,7 +36,7 @@ class PersonRepo(BaseSqlaRepo[PersonAppORM]):
             query = query.where(PersonAppORM.last_updated > from_date)
         if filters and filters.strict:
             if filters.telegram:
-                query = query.filter_by(telegram=filters.telegram)
+                query = query.where(func.lower(PersonAppORM.telegram) == func.lower(filters.telegram))
             if filters.phone:
                 query = query.filter_by(phone=filters.phone)
             if filters.email:

--- a/app/routers/people.py
+++ b/app/routers/people.py
@@ -81,9 +81,10 @@ async def get_telebot_person(
     - https://github.com/Insomnia-IT/promocode_bot
     - https://git.asocialpsihopat.net/samson/promocode_bot_cw
     """
-    person = await repo.retrieve(None, PersonFiltersDTO(telegram=telegram, strict=True))
+    clean = telegram.strip().lstrip("@").lower()
+    person = await repo.retrieve(None, PersonFiltersDTO(telegram="@" + clean, strict=True))
     if not person:
-        person = await repo.retrieve(None, PersonFiltersDTO(telegram="@" + telegram, strict=True))
+        person = await repo.retrieve(None, PersonFiltersDTO(telegram=clean, strict=True))
     if not person:
         return None
     participations = await repo_part.retrieve_personal(person.nocode_int_id, True)


### PR DESCRIPTION
## Описание

Telegram username в базе данных хранятся в разном регистре (например, `sheffer_olga` vs `NeboGoroda`). Эндпоинт `/contacts/search` использовал строгое сравнение (`PersonAppORM.telegram == value`), поэтому запрос с несовпадающим регистром возвращал `null`, хотя человек в базе есть.

## Изменения

### `app/db/repos/person.py`
- Добавлен импорт `func` из sqlalchemy
- `filter_by(telegram=...)` заменён на `where(func.lower(telegram) == func.lower(value))` в strict-режиме — сравнение регистронезависимое

### `app/routers/people.py`
- Нормализация входа: `strip()`, `lstrip(@)`, `.lower()`
- Поиск сначала с `@` + нормализованное значение (основной сценарий — в БД данные с `@`)
- Fallback без `@` (edge-case для записей без префикса)
- Исправлен баг: старый fallback дописывал `@` к сырому входу, что могло дать `@@username`, если `@` уже был передан

## Коммит

`7135296` — 2 файла, +5/−4 строк

## Проверка

После деплоя:

| Запрос | Ожидание |
|--------|----------|
| `…/contacts/search?telegram=Sheffer_Olga` | `200` (было `null`) |
| `…/contacts/search?telegram=sheffer_olga` | `200` |
| `…/contacts/search?telegram=@Sheffer_Olga` | `200` |
| `…/contacts/search?telegram=NeboGoroda` | `200` |
| `…/contacts/search?telegram=nebogoroda` | `200` (было `null`) |
| `…/contacts/search?telegram=nonexistent` | `null` |